### PR TITLE
ADDS: Color output to via Click

### DIFF
--- a/cosmopy/__main__.py
+++ b/cosmopy/__main__.py
@@ -2,6 +2,7 @@
 """
 import argparse
 import sys
+import click
 
 import numpy as np
 import astropy as ap
@@ -135,7 +136,6 @@ def output_print(results, print_output=True):
              'Angular Diameter Distance', 'Arcsecond Scale', 'Lookback Time',
              'Age of the Universe', 'Distance Modulus']
 
-    outs = []
     retvals = {}
     for kk, ss, tt, nn in zip(keys, symbs, types, names):
         vv = results[kk]
@@ -157,12 +157,14 @@ def output_print(results, print_output=True):
         except Exception:
             conv = ""
 
-        rstr = "{base:30s}{conv:20s} : {name}".format(base=base, conv=conv, name=nn)
-        retvals[kk] = rstr
-        outs.append(rstr)
+        retvals[kk] = {"base":base, "conv":conv, "name":nn}
 
     if print_output:
-        print("\n" + "\n".join(outs) + "\n")
+        for key in retvals:
+            click.secho('{base:30s}'.format(base=retvals[key]['base']), bold=True, nl=False, fg="cyan")
+            click.secho('{conv:20s}'.format(conv=retvals[key]['conv']), bold=False, nl=False, fg="yellow")
+            click.secho(' : ', bold=True, nl=False, fg="green")
+            click.secho('{name}'.format(name=retvals[key]["name"]), bold=False, nl=True, fg="red")
 
     return retvals
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Bnumpy
+numpy
 scipy
 astropy
 nose

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
-numpy
+Bnumpy
 scipy
 astropy
 nose
 coverage
 future
+click


### PR DESCRIPTION
Adds color output to the terminal with the [Click](http://click.pocoo.org/5/) module. In order to do this I added click to requirements.txt and the __main__.py import. The `output_print()` function had to be rewritten slightly to support that, which changes the structure of the `retvals` return variable. Not sure if that breaks something down the line...

See image below for example. Colors can be customized.

![capture](https://user-images.githubusercontent.com/8881836/34505185-61c25e1c-efd8-11e7-966d-f5b69ae29037.JPG)

